### PR TITLE
Reorganize

### DIFF
--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -1,4 +1,4 @@
-# Introduction {#intro}
+# Package Development Guidelines {-}
 
 **version `r read.dcf("DESCRIPTION")[,"Version"]` (`r read.dcf("DESCRIPTION")[, "Date"]`)**
 

--- a/16-references.Rmd
+++ b/16-references.Rmd
@@ -1,5 +1,5 @@
 `r if (knitr::is_html_output()) '
-# References {-}
+# References 
 '`
 
 <div id="refs"></div>

--- a/17-reviewer-expectations.Rmd
+++ b/17-reviewer-expectations.Rmd
@@ -1,0 +1,104 @@
+# Reviewer Expectations {-}
+
+Anyone from the Bioconductor community can volunteer to become a Bioconductor
+community reviewer to review incoming packages submitted through the [New
+Submission Tracker](https://github.com/Bioconductor/Contributions/issues). The
+following overviews what is expected of community reviewers.
+
+
+## Qualifications {-}
+
+Actively maintaining a Bioconductor package 
+
+
+## Time Commitment  {-}
+
+Package reviews can vary depending on the quality and organization of the
+submitted package. On average a package review for a single package is between
+30 min - 1.5 hour.
+
+We also plan to have a quarterly “all-hands” meeting of all currently active
+reviewers.  This meeting will be to acquaint reviewers with any new
+requirements, classes, checks activated in CRAN or BiocCheck, etc. It will also
+be a place to raise questions or comments to the larger group and perhaps point
+out frequently used comments (that perhaps could be implemented as an automated
+check).  Everyone ends up having slightly different review styles and it could
+be beneficial to discuss what everyone finds a priority. Every effort should be
+made to attend these meetings and we would expect a reviewer to attend at least
+once a year.
+
+
+## Assignments  {-}
+
+Packages will be assigned evenly and randomly, the more community review
+engagement the more distributed but currently anticipate a package assigned once
+every week or every 2 weeks. More during the weeks leading up to a Bioconductor
+release.
+
+'Additional Package'/'Circular dependency' packages are submitted occasionally.
+Submitters are allowed to submit related packages under the same issue. When
+this occurs, the assigned reviewer is responsible for both reviews and should
+not accept the issue until both packages are in an accepted state.
+
+
+## Expectations and deadline  {-}
+
+Package will be expected to be reviewed within 3 weeks of assignment and a clean
+build report from the build machine.  We plan to make a hard limit for 3
+weeks. If the delay is on the submitter, the issue will be closed for
+inactivity; it will be reopened when a submitter can committee to timely updates
+and engagement of the review process.  If the delay is in the reviewer, it will
+be reassigned to someone else.  We will keep track of how many reassignments
+occur and if there are frequent reassignments (3-4 unexplained) we will remove
+from being an active reviewer and the person must reapply to be
+reactivated. Active reviewers are expected to review at least 1 package per
+Bioconductor release cycle. Otherwise they will be removed from being an active
+reviewer.
+
+
+## Requesting reassignment and temporary leave of assignment  {-}
+
+If a temporary leave of assigning packages needs to occur (vacation,
+particularly busy period of time, etc) , a reviewer should reach out to a
+package review committee administrator. The administrator will temporarily stop
+assignments and can discuss if currently assigned packages need re-assignment.
+
+There is a slack channel for package reviewers to ask questions and if necessary
+ask to swap/switch/volunteer to review packages. Requests can also be made by
+directly contacting the package review administrator.
+
+Reviewers should not request reassignment simply because of lack of interest or
+lack of expertise in a particular area. The review should focus on ease-of-use
+of the package, documentation, well written code, and interoperability. If a
+reviewer knows of a particular ‘expert’ in the field relating to the submitted
+package they can request someone offer additional comments (including those not
+officially part of the package review list) without explicitly asking for
+reassignment.
+
+
+## On-boarding  {-}
+
+New volunteers will undergo an on-boarding process before becoming fully active
+reviewers. The on-boarding process involves doing at least one paired review
+with a currently active reviewing member. Coordination of the paired review
+should be communicated between the mentor and mentee. The recommended practice
+will be that each do a separate review of a currently submitted package and
+compare the results. The currently active member will then decide if another
+paired review is necessary or if the review was sufficient to continue on with
+solo reviews.
+
+
+## Recognition {-}
+
+Feel free to advertise on CV and resumes as being a Bioconductor reviewer.
+Reviewers will also be listed on the [Community Reviewers Webpage](). Reviewers
+may optionally opt-out of being listed on the webpage by contacting a package
+review administrator. Ideally, we plan to have badges for notable achievements
+and milestones, and a sticker is in progress.
+
+
+## Volunteer {-}
+
+To apply to become a community reviewer, please fill out the following:
+[Form](https://forms.gle/myLWsb7JVVrZa3xM9)
+

--- a/17-reviewer-resources.Rmd
+++ b/17-reviewer-resources.Rmd
@@ -1,0 +1,5 @@
+# Package Reviewer Resources {-}
+
+The following sections contain resources for package reviewers and those
+interested in becoming package reviewers. You will find reviewer expectations,
+useful tools, and how to volunteer to be a community reviewer.

--- a/18-reviewer-expectations.Rmd
+++ b/18-reviewer-expectations.Rmd
@@ -1,10 +1,9 @@
-# Reviewer Expectations {-}
+# Review Expectations {#expectations}
 
 Anyone from the Bioconductor community can volunteer to become a Bioconductor
 community reviewer to review incoming packages submitted through the [New
 Submission Tracker](https://github.com/Bioconductor/Contributions/issues). The
 following overviews what is expected of community reviewers.
-
 
 ## Qualifications {-}
 

--- a/19-reviewer-tools.Rmd
+++ b/19-reviewer-tools.Rmd
@@ -1,0 +1,8 @@
+# Reviewer Resources and Tools {#reviewtools}
+
+Reviewers may find the following links and references useful.
+
+
+## Package Review checklist
+
+## Example Review

--- a/20-become-a-reviewer.Rmd
+++ b/20-become-a-reviewer.Rmd
@@ -1,0 +1,9 @@
+# Volunteer to Review {#volunteer}
+
+Anyone from the Bioconductor community can volunteer to become a Bioconductor
+community reviewer to review incoming packages submitted through the [New
+Submission
+Tracker](https://github.com/Bioconductor/Contributions/issues). Please review
+the [Reviewer Expectations](#expectations) and the [Bioconductor Code of
+Conduct](https://bioconductor.org/about/code-of-conduct/) before filling out the
+[volunteer form](https://forms.gle/myLWsb7JVVrZa3xM9)

--- a/index.Rmd
+++ b/index.Rmd
@@ -23,7 +23,7 @@ knitr::include_graphics("https://raw.githubusercontent.com/Bioconductor/BiocStic
 
 [_Bioconductor_](https://bioconductor.org/) uses the <i class="fab fa-r-project"></i> statistical programming language [@r2021], and is open source and open development. It has two releases each year, and an active user community.
 
-[_Bioconductor_](https://bioconductor.org/) is also available as an [AMI](https://bioconductor.org/help/bioconductor-cloud-ami/) (Amazon Machine Image) and [Docker](https://bioconductor.org/help/docker/) images.
+[_Bioconductor_](https://bioconductor.org/) is also available as [Docker](https://bioconductor.org/help/docker/) images.
 
 ```{r include=FALSE}
 # automatically create a bib database for R packages


### PR DESCRIPTION
Ok.  See what you think about this reorganization.  I tried to make unnumber sections and distinction between what would be good for developers and  reference for the reviewers.  

The reviewer tools sections -- I wasn't sure if there was a way to cross reference Johanne's document in the docs?  and vince and I talked about posting a link to a few completed reviews for reference (we were going to look and ask some of the newly added core packages if they would mind going up) 

And as before I'll update the webpage reference when we are set to go -- I didn't want to post the webpage yet until we were set to roll everything out but there is a branch there set to go too