### PR TITLE
Change links to point to Bioconductor repository

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -4,7 +4,7 @@ bookdown::bs4_book:
     yellow: "#804600"
     h4-font-size: "1.1rem"
     headings-color: "#87b13f"
-  repo: https://github.com/kevinrue/bioc_package_guide
+  repo: https://github.com/Bioconductor/pkgrevdocs
 # Refer to https://rstudio.github.io/bslib/articles/bs4-variables.html for theme variable names
 
 bookdown::pdf_book:


### PR DESCRIPTION
I tried to edit the book from http://contributions.bioconductor.org/reviewtools.html using the "Edit this book" on the right menu but I couldn't because it pointed to https://github.com/kevinrue/bioc_package_guide/edit/master/19-reviewer-tools.Rmd, this change should fix these links. 