### PR TITLE
Fix links to the DESCRIPTION file section

### DIFF
--- a/package-data.Rmd
+++ b/package-data.Rmd
@@ -27,7 +27,7 @@ See the [Package Submission guidelines](https://www.bioconductor.org/developers/
 [_Bioconductor_](https://bioconductor.org/) strongly encourages the use of existing datasets, but if not available data can be included directly in the package for use in the examples found in man pages, vignettes, and tests of your package.
 This is a good reference by [Hadley Wickham about data](http://r-pkgs.had.co.nz/data.html).
 
-However, as mentioned in [The DESCRIPTION file](the-description-file.html#lazydata) chapter, [_Bioconductor_](https://bioconductor.org/) does not encourage using `LazyData: True` despite its recommendataion in this article.
+However, as mentioned in [The DESCRIPTION file](description.html#lazydata) chapter, [_Bioconductor_](https://bioconductor.org/) does not encourage using `LazyData: True` despite its recommendataion in this article.
 
 Some key points are summarized in the following sections.
 

--- a/r-code.Rmd
+++ b/r-code.Rmd
@@ -9,7 +9,7 @@ There are also some other key points, detailed in the following sections.
 
 ## License
 
-Only contain code that can be distributed under the license specified (see also [The DESCRIPTION file](the-description-file.html#license)).
+Only contain code that can be distributed under the license specified (see also [The DESCRIPTION file](description.html#license)).
 
 ## `R CMD check` and `BiocCheck`
 
@@ -46,7 +46,7 @@ from a variable.
 ### Re-use of functionality, classes, and generics
 
 Avoid re-implementing functionality or classes (see also
-[The DESCRIPTION file](the-description-file.html#depends-imports-suggests-enhances)).
+[The DESCRIPTION file](description.html#depends-imports-suggests-enhances)).
 Make use of appropriate existing packages (e.g.,
 `r BiocStyle::Biocpkg("biomaRt")`,
 `r BiocStyle::Biocpkg("AnnotationDbi")`,


### PR DESCRIPTION
Fix links to the DESCRIPTION file section that went to `the-description-file.html` instead of `description.html`.