### PR TITLE
rename master to devel in documentation, resolves #79

### DIFF
--- a/git-version-control.Rmd
+++ b/git-version-control.Rmd
@@ -28,23 +28,23 @@ Two useful commands are
     BiocGenerics$ git log      # review recent commits
 
 If the repository is already cloned, the work flow is to make sure
-that you are on the 'master' branch, pull any changes, then introduce
+that you are on the 'devel' branch, pull any changes, then introduce
 your edits.
 
-    BiocGenerics$ git checkout master
+    BiocGenerics$ git checkout devel
     BiocGenerics$ git pull
     ## add, edit, commit, and push as above
 
 ## Where to Commit Changes
 
-New features and bug fixes are introduced on the master ('devel')
-branch of the GIT repository.
+New features and bug fixes are introduced on the devel branch of the GIT
+repository.
 
-    BiocGenerics$ git checkout master
+    BiocGenerics$ git checkout devel
     BiocGenerics$ git pull
-    ## edit 'R/foo.R' and commit on master
+    ## edit 'R/foo.R' and commit on devel
     BiocGenerics$ git commit R/foo.R  #
-    [master c955179] your commit message
+    [devel c955179] your commit message
     1 file changed, 10 insertions(+), 3 deletions(-)
     BiocGenerics$ git push
 
@@ -52,10 +52,10 @@ To make more extensive changes see [Fix bugs in devel and release][].
 
 Bug fixes can be ported to the current release branch. Use
 `cherry-pick` to identify the commmit(s) you would like to port. E.g.,
-for release 3.6, porting the most recent commit to master
+for release 3.6, porting the most recent commit to devel
 
     BiocGenerics$ git checkout RELEASE_3_6
-    BiocGenerics$ git cherry-pick master
+    BiocGenerics$ git cherry-pick devel
     BiocGenerics$ git push
 
 ## Checks and version bumps
@@ -163,18 +163,18 @@ pushing to the _Bioconductor_ git repository.
         git fetch --all
 
         ## merge changes from Bioc (upstream remote at git@git.bioconductor.org)
-        git merge upstream/master
+        git merge upstream/devel
 
         ## merge changes from GitHub (origin remote)
-        git merge origin/master
+        git merge origin/devel
 
-   **Note**. If your GitHub default branch is `main`, replace `master` with
+   **Note**. If your GitHub default branch is `main`, replace `devel` with
         `main`:
 
         ## merge changes from GitHub (origin remote)
         git merge origin/main
 
-   Make changes to your package master branch and commit them to your
+   Make changes to your package devel branch and commit them to your
    local repository
 
         git add <files changed>
@@ -196,16 +196,16 @@ pushing to the _Bioconductor_ git repository.
    GitHub repositories.
 
         ## push to BioC (upstream remote at git@git.bioconductor.org)
-        git push upstream master
+        git push upstream devel
 
         ## push to GitHub (origin remote)
-        git push origin master
+        git push origin devel
 
-   **Note**. If your GitHub default branch is `main`, replace `master` with
+   **Note**. If your GitHub default branch is `main`, replace `devel` with
         `main`:
 
         ## push to Bioc (upstream remote at git@git.bioconductor.org)
-        git push upstream main:master
+        git push upstream main:devel
 
         ## push to GitHub (origin remote)
         git push origin main
@@ -278,23 +278,23 @@ user community can engage in the development of your package.
 
         git fetch upstream
 
-1.  Merge upstream with origin's master branch,
+1.  Merge upstream with origin's devel branch,
 
-        git merge upstream/master
+        git merge upstream/devel
 
     __NOTE:__ If you have the error `fatal: refusing to merge
     unrelated histories`, then the repository cloned in step 4 was not
     empty. Either clone an empty repository, or see
     [Sync existing repositories][].
 
-1. Push changes to your origin master,
+1. Push changes to your origin devel,
 
-        git push origin master
+        git push origin devel
 
     __NOTE:__ Run the command `git config --global push.default
     matching` to always push local branches to the remote branch of
     the same name, allowing use of `git push origin` rather than `git
-    push origin master`.
+    push origin devel`.
 
 1.  (Optional) Add a branch to GitHub,
 
@@ -307,7 +307,7 @@ user community can engage in the development of your package.
         ## Push updates to remote origin's new branch RELEASE_3_6
         git push -u origin RELEASE_3_6
 
-1. Check your GitHub repository to confirm that the `master` (and
+1. Check your GitHub repository to confirm that the `devel` (and
    optionally `RELEASE_3_6`) branches are present.
 
 1. Once the GitHub repository is established follow
@@ -362,18 +362,18 @@ without using GitHub.
         git pull
 
 1. Make the required changes, then `add` and `commit` your changes to
-   your `master` branch.
+   your `devel` branch.
 
         git add <files changed>
         git commit -m "My informative commit message"
 
 1. (Alternative) If the changes are non-trivial, create a new branch
    where you can easily abandon any false starts. Merge the final
-   version onto `master`
+   version onto `devel`
 
         git checkout -b feature-my-feature
         ## add and commit to this branch. When the change is complete...
-        git checkout master
+        git checkout devel
         git merge feature-my-feature
 
 #### Push your local commits to the _Bioconductor_ repository
@@ -381,17 +381,17 @@ without using GitHub.
 1. Push your commits to the _Bioconductor_ repository to make them
    available to the user community.
 
-   Push changes to the `master` branch using:
+   Push changes to the `devel` branch using:
 
-        git checkout master
-        git push upstream master
+        git checkout devel
+        git push upstream devel
 
 Make sure there is a valid version bump for the changes to propagate to users.
 
 #### (Optional) Merge changes to the current release branch
 
-Merging master into release branch should be avoided. Select bug fixes should be
-cherry-picked from master to release. See section [Bug Fixes in Release and Devel](#bug-fix-in-release-and-devel)
+Merging devel into release branch should be avoided. Select bug fixes should be
+cherry-picked from devel to release. See section [Bug Fixes in Release and Devel](#bug-fix-in-release-and-devel)
 
 
 ## More scenarios for repository creation
@@ -418,36 +418,36 @@ repositories are all in sync.
 
         git fetch --all
 
-1. Make sure you are on the master branch.
+1. Make sure you are on the devel branch.
 
-        git checkout master
+        git checkout devel
 
 1. Merge updates from the GitHub (`origin`) remote
 
-        git merge origin/master
+        git merge origin/devel
 
 1. Merge updates from the _Bioconductor_ (`upstream`) remote
 
-        git merge upstream/master
+        git merge upstream/devel
 
    Users of git version >= 2.9 will see an error message ("fatal:
    refusing to merge unrelated histories") and need to use
 
-        git merge --allow-unrelated-histories upstream/master
+        git merge --allow-unrelated-histories upstream/devel
 
 1. [Resolve merge conflicts][mergeconflict] if necessary.
 
 1. After resolving conflicts and committing changes, look for duplicate
    commits (e.g., `git log --oneline | wc` returns twice as many
    commits as in SVN) and consider following the steps to
-   [force Bioconductor `master` to GitHub `master`][force-bioc-to-github].
+   [force Bioconductor `devel` to GitHub `devel`][force-bioc-to-github].
 
 1. Push to both _Bioconductor_  and GitHub repositories.
 
-        git push upstream master
-        git push origin master
+        git push upstream devel
+        git push origin devel
 
-1. Repeat for the release branch, replacing `master` with the name of
+1. Repeat for the release branch, replacing `devel` with the name of
    the release branch, e.g., `RELEASE_3_6`. It may be necessary to
    create the release branch in the local repository.
 
@@ -463,14 +463,14 @@ repositories are all in sync.
         git checkout -b <RELEASE_X_Y> upstream/<RELEASE_X_Y>
 
     Following this one time local checkout, you may switch between
-    `RELEASE_X_Y` and `master` with `git checkout <RELEASE_X_Y>`. If you do
+    `RELEASE_X_Y` and `devel` with `git checkout <RELEASE_X_Y>`. If you do
     not use the command to get a local copy of the release branch, you
     will get the message,
 
        (HEAD detached from origin/RELEASE_X_Y)
 
 
-   Remember that only `master` and the current release branch of
+   Remember that only `devel` and the current release branch of
    _Bioconductor_ repositories can be updated.
 
 
@@ -530,11 +530,11 @@ __NOTE:__ It is always a good idea to fetch updates from
 _Bioconductor_ before making more changes. This will help prevent
 merge conflicts.
 
-These steps update the `master` branch.
+These steps update the `devel` branch.
 
 1. Make sure you are on the appropriate branch.
 
-        git checkout master
+        git checkout devel
 
 1. Fetch content from _Bioconductor_
 
@@ -542,16 +542,16 @@ These steps update the `master` branch.
 
 1. Merge upstream with the appropriate local branch
 
-        git merge upstream/master
+        git merge upstream/devel
 
     Get help on [Resolve merge conflicts][mergeconflict] if these occur.
 
 1. If you also maintain a GitHub repository, push changes to GitHub's
-   (`origin`) `master` branch
+   (`origin`) `devel` branch
 
-        git push origin master
+        git push origin devel
 
-To pull updates to the current `RELEASE_X_Y` branch, replace `master`
+To pull updates to the current `RELEASE_X_Y` branch, replace `devel`
 with `RELEASE_X_Y` in the lines above.
 
 See instructions to [Sync existing repositories][] with
@@ -561,7 +561,7 @@ changes to both the _Bioconductor_ and GitHub repositories.
 ### Push to GitHub and _Bioconductor_ repositories {#push-to-github-bioc}
 
 __Goal:__ During everyday development, you commit changes to your
-local repository `master` branch, and wish to push these commits to
+local repository `devel` branch, and wish to push these commits to
 both GitHub and _Bioconductor_ repositories.
 
 __NOTE:__ See [Pull upstream changes][] for best practices before
@@ -587,9 +587,9 @@ committing local changes.
 		upstream    git@git.bioconductor.org:packages/BiocGenerics.git (fetch)
 		upstream    git@git.bioconductor.org:packages/BiocGenerics.git (push)
 
-1. Make and commit changes to the `master` branch
+1. Make and commit changes to the `devel` branch
 
-		git checkout master
+		git checkout devel
 		## edit files, etc.
 		git add <name of file changed>
 		git commit -m "My informative commit message describing the change"
@@ -597,26 +597,26 @@ committing local changes.
 1. (Alternative) When changes are more elaborate, best practice is to
    use a local branch for development.
 
-		git checkout master
+		git checkout devel
 		git checkout -b feature-my-feature
 		## multiple rounds of edit, add, commit
 
-	Merge the local branch to master when the feature is 'complete'.
+	Merge the local branch to devel when the feature is 'complete'.
 
-		git checkout master
+		git checkout devel
 
 		# Pull upstream changes before merging
 		# http://bioconductor.org/developers/how-to/git/pull-upstream-changes/
 
 		git merge feature-my-feature
 
-1. Push updates to GitHub's (`origin`) `master` branch
+1. Push updates to GitHub's (`origin`) `devel` branch
 
-		git push origin master
+		git push origin devel
 
-1.  Next, push updates to _Bioconductor_'s (`upstream`) `master` branch
+1.  Next, push updates to _Bioconductor_'s (`upstream`) `devel` branch
 
-		git push upstream master
+		git push upstream devel
 
 1. Confirm changes, e.g., by visiting the GitHub web page for the repository.
 
@@ -629,7 +629,7 @@ _Bioconductor_ repositories.
 1. You will know you have a merge conflict when you see something like
    this:
 
-        git merge upstream/master
+        git merge upstream/devel
         Auto-merging DESCRIPTION
         CONFLICT (content): Merge conflict in DESCRIPTION
         Automatic merge failed; fix conflicts and then commit the result
@@ -650,8 +650,8 @@ _Bioconductor_ repositories.
 
     This will show you something like this:
 
-	    On branch master
-	    Your branch is ahead of 'origin/master' by 1 commit.
+	    On branch devel
+	    Your branch is ahead of 'origin/devel' by 1 commit.
           (use "git push" to publish your local commits)
 	    You have un-merged paths.
 	      (fix conflicts and run "git commit")
@@ -670,11 +670,11 @@ _Bioconductor_ repositories.
 	    Version: 0.23.2
 	    =======
         Version: 0.23.3
-	    >>>>>>> upstream/master
+	    >>>>>>> upstream/devel
 
 	Everything between `<<<<` and `=====` refers to HEAD, i.e your
     current change. And everything between `=====` and `>>>>>` refers
-    to the `remote/branch` shown there, i.e `upstream/master`.
+    to the `remote/branch` shown there, i.e `upstream/devel`.
 
 	You want to keep the most accurate change, by deleting what is
     necessary. In this case, keep the latest version:
@@ -688,8 +688,8 @@ _Bioconductor_ repositories.
 
 1. 	Push to both your GitHub and _Bioconductor_ repositories,
 
-	    git push origin master
-	    git push upstream master
+	    git push origin devel
+	    git push upstream devel
 
 #### Extra Resources
 
@@ -706,42 +706,42 @@ __Goal:__ You want to start fresh after failing to resolve conflicts
 or some other issue. If you intend to go nuclear, please contact the
 bioc-devel@bioconductor.org mailing list.
 
-#### Force _Bioconductor_ `master` to GitHub `master`
+#### Force _Bioconductor_ `devel` to GitHub `devel`
 
 One way you can ignore your work and make a new branch is by replacing
-your local and GitHub repository `master` branch with the
-_Bioconductor_ `master` branch.
+your local and GitHub repository `devel` branch with the
+_Bioconductor_ `devel` branch.
 
 __Note__: This works only if you haven't pushed the change causing the
 issue to the _Bioconductor_ repository.
 
-__Note__: Any references to commits on current master (e.g., in GitHub
+__Note__: Any references to commits on current devel (e.g., in GitHub
 issues) will be invalidated.
 
-1. Checkout a new branch, e.g., `master_backup`, with tracking set to
-   track the _Bioconductor_ `master` branch `upstream/master`.
+1. Checkout a new branch, e.g., `devel_backup`, with tracking set to
+   track the _Bioconductor_ `devel` branch `upstream/devel`.
 
-        git checkout -b master_backup upstream/master
+        git checkout -b devel_backup upstream/devel
 
 1. Rename the branches you currently have on your local
-   machine. First, rename `master` to `master_deprecated`. Second,
-   rename `master_backup` to `master`. This process is called the
+   machine. First, rename `devel` to `devel_deprecated`. Second,
+   rename `devel_backup` to `devel`. This process is called the
    classic __Switcheroo__.
 
-        git branch -m master master_deprecated
-        git branch -m master_backup master
+        git branch -m devel devel_deprecated
+        git branch -m devel_backup devel
 
 1. You will now have to "force push" the changes to your GitHub
-   (`origin`) `master` branch.
+   (`origin`) `devel` branch.
 
-        git push -f origin master
+        git push -f origin devel
 
-1. __(Optional)__ If you have commits on your `master_deprecated`
-   branch that you would like ported on to your new `master`
+1. __(Optional)__ If you have commits on your `devel_deprecated`
+   branch that you would like ported on to your new `devel`
    branch. Git has a special feature called `cherry-pick`
 
    Take a look at which commit you want to cherry-pick on to the new
-   master branch, using `git log master_deprecated`, copy the correct
+   devel branch, using `git log devel_deprecated`, copy the correct
    commit id, and use:
 
         git cherry-pick <commit id>
@@ -805,16 +805,16 @@ git branch and in the current release branch (e.g., `RELEASE_3_14`).
 1. First [Sync existing repositories][].
 
         git fetch --all
-        git checkout master
-        git merge upstream/master
-        git merge origin/master
+        git checkout devel
+        git merge upstream/devel
+        git merge origin/devel
         git checkout <RELEASE_X_Y>
         git merge upstream/<RELEASE_X_Y>
         git merge origin/<RELEASE_X_Y>
 
-1. On your local machine, be sure that you are on the `master` branch.
+1. On your local machine, be sure that you are on the `devel` branch.
 
-        git checkout master
+        git checkout devel
 
    Make the changes needed to fix the bug and add the modified files
    to the commit. Remember to bump the version number in the `DESCRIPTION` file
@@ -840,13 +840,13 @@ git branch and in the current release branch (e.g., `RELEASE_3_14`).
 1. (Alternative) If the changes are non-trivial i.e., with multiple commits,
    create a new branch where you can easily abandon any false starts.
 
-        git checkout master
+        git checkout devel
         git checkout -b bugfix-my-bug
         ## add and commit to this branch to fix the bug
 
    Merge the final version of the branch into the default branch.
 
-        git checkout master
+        git checkout devel
         git merge bugfix-my-bug
 
 1. Switch to the release branch and `cherry-pick` the commit hash or range of
@@ -868,20 +868,20 @@ git branch and in the current release branch (e.g., `RELEASE_3_14`).
         git checkout -b <RELEASE_X_Y> upstream/<RELEASE_X_Y>
 
     Following this one time local checkout, you may switch between RELEASE_X_Y
-    and master with `git checkout <RELEASE_X_Y>`. If you do not use the command
+    and devel with `git checkout <RELEASE_X_Y>`. If you do not use the command
     to get a local checkout of the release branch, you will get the message:
 
         (HEAD detached from origin/RELEASE_X_Y)
 
-1. Push your changes to both the GitHub and _Bioconductor_ `master`
+1. Push your changes to both the GitHub and _Bioconductor_ `devel`
    and `<RELEASE_X_Y>` branches. Make sure you are on the correct
    branch on your local machine.
 
-   For the `master` branch,
+   For the `devel` branch,
 
-        git checkout master
-        git push upstream master
-        git push origin master
+        git checkout devel
+        git push upstream devel
+        git push origin devel
 
    For the `release` branch,
 
@@ -906,14 +906,14 @@ Bioconductor.
 #### Steps:
 
 1. **IMPORTANT** Make a backup of the branch with duplicate commits,
-   call this `master_backup` (or `RELEASE_3_7_backup`). The name of
+   call this `devel_backup` (or `RELEASE_3_7_backup`). The name of
    the back up branch should be identifiable and specific to the
-   branch you are trying to fix (i.e if you want to fix the *master*
+   branch you are trying to fix (i.e if you want to fix the *devel*
    branch or some `<RELEASE_X_Y>` branch).
 
-   On master, (make sure you are on master by `git checkout master`)
+   On devel, (make sure you are on devel by `git checkout devel`)
 
-		git branch master_backup
+		git branch devel_backup
 
 
 2. Identify the commit from which the duplicates have
@@ -923,7 +923,7 @@ Bioconductor.
 
 		git reset —hard <commit_id>
 
-4. Now cherry pick your commits from the `master_backup` branch.
+4. Now cherry pick your commits from the `devel_backup` branch.
 
 		git cherry-pick <commit_id>
 
@@ -994,9 +994,9 @@ Once you have accepted pull requests from your package community on
 GitHub, you can push these changes to _Bioconductor_.
 
 1. Make sure that you are on the branch to which the changes were
-   applied, for example `master`.
+   applied, for example `devel`.
 
-        git checkout master
+        git checkout devel
 
 1. Fetch and merge the GitHub changes to your local repository.
 
@@ -1007,10 +1007,10 @@ GitHub, you can push these changes to _Bioconductor_.
 
 1. Push your local repository to the upstream _Bioconductor_ repository.
 
-        git push upstream master
+        git push upstream devel
 
     To push GitHub release branch updates to the _Bioconductor_
-    release branch, replace `master` with name of the release branch,
+    release branch, replace `devel` with name of the release branch,
     e.g.: `RELEASE_3_6`.
 
 
@@ -1041,76 +1041,16 @@ maintain the package and avoid deprecation and removal.
 
 __Goal:__ Git remembers. Sometimes large data files are added to git
 repository (intentionally or unintentionally) causing the size of the repository
-to become large. When this happens, it's not enough to just remove the files.
-You also must remove them from the git tree (the repository history), or else
-your repository will remain large.
+to become large. It is necessary to remove the files and clean the git tree from
+tracking in order to reduce the size.
 
-There are a few ways to remove large files from a git history. Here, we'll
-outline two options: 1) `git filter-repo`, and 2) the BFG repo cleaner. 
 These steps should be run on your local copy and (if necessary) pushed to your
-own github repository.
-
-#### Removing Large Files from History with filter-repo
-
-As of 2023, the recommended way is to first locate any large files, and 
-then remove them with `git filter-repo`.
-
-1. Identify large files using [this git rev-list script](
-https://stackoverflow.com/a/42544963):
-
-```
-git rev-list --objects --all \
-| git cat-file --batch-check='%(objecttype) %(objectname) %(objectsize) %(rest)' \
-| sed -n 's/^blob //p' \
-| sort --numeric-sort --key=2 \
-| cut -c 1-12,41- \
-| $(command -v gnumfmt || echo numfmt) --field=2 --to=iec-i --suffix=B --padding=7 --round=nearest
-```
-
-This will list all the objects in your repository, including objects in your
-history, in order of file size. Use this to identify the names of files to remove.
-
-2. Remove them with [filter-repo](https://github.com/newren/git-filter-repo).
-
-This is a separate tool that you'll have to install 
-(with *e.g.* `pip3 install git-filter-repo`). Then, you can rewrite your repository
-history to remove files like this, where `<file-glob>` identifies your files:
-
-```
-git filter-repo --path-glob '<file-glob>' --invert-paths
-```
-
-For example, to remove all `.RData` files, you could use:
-
-```
-git filter-repo --path-glob '*.RData' --invert-paths
-```
-
-This command may reset your remotes. Check with `git remote` and
-if needed, you can add remotes back in using something like this:
-
-```
-git remote add origin git@github.com:<username>/<repo_name>
-git push --set-upstream origin master --force
-```
-
-Finally, we have to push with `--mirror` to reset the remote.
-
-```
-git push --force --mirror
-```
-
-Now, just notify everyone that they'll have to re-clone the new repository, since 
-history has been rewritten, so existing clones will no longer be compatible
-with this repo.
-
-#### Removing Large Files from History with BFG repo cleaner
-
-Another option is to use BFG. The steps below assume `origin` is a user-maintained github
+own github repository. The steps below assume origin is a user maintained github
 repository.
 
 **NOTE:** Anyone that is maintaining the package repository (with a local copy)
   should run steps 1-3.
+
 
 1. Download [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/)
 
@@ -1276,7 +1216,7 @@ repository.
     `ExamplePackage`: This is being used a place holder for a package
     name.
 
-    SVN `trunk` and git `master` branch are now the development
+    SVN `trunk` and git `devel` branch are now the development
     branches.
 
 1. I'm a _Bioconductor_ developer only on the _Bioconductor_ server. I do
@@ -1291,7 +1231,7 @@ repository.
 
 1. I cannot push to my package. I get the error,
 
-        $ git push origin master
+        $ git push origin devel
         fatal: remote error: FATAL: W any packages/myPackage nobody DENIED by fallthru
         (or you mis-spelled the reponame)
 
@@ -1395,7 +1335,7 @@ repository.
 
 1. Can I create and push new branches to my repository on git.bioconductor.org?
 
-    No. Maintainers only have access to `master` and the current `RELEASE_X_Y`.
+    No. Maintainers only have access to `devel` and the current `RELEASE_X_Y`.
     New branches cannot be created and pushed to the bioconductor server. We
     recommend maintainers have additional branches on their Github repository
     if they are maintaining one.

--- a/index.Rmd
+++ b/index.Rmd
@@ -92,7 +92,7 @@ knitr::write_bib(c(
 [exptdata-pkgs]: https://bioconductor.org/packages/release/data/experiment/
 [exptdata-views]: https://bioconductor.org/packages/release/BiocViews.html#___ExperimentData
 [Fix bugs in devel and release]: #bug-fix-in-release-and-devel
-[force-bioc-to-github]: #force-bioconductor-master-to-github-master
+[force-bioc-to-github]: #force-bioconductor-devel-to-github-devel
 [Github collaborators]: https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-user-account/managing-access-to-your-personal-repositories/inviting-collaborators-to-a-personal-repository
 [git]: https://git.bioconductor.org
 [git-repo-create]: https://help.github.com/articles/create-a-repo/


### PR DESCRIPTION
Note. The PR should be merged after the symbolic-ref is created