### PR TITLE
Fix non-existing branch error in section "Subversion to Git Transition"

### DIFF
--- a/git-version-control.Rmd
+++ b/git-version-control.Rmd
@@ -280,6 +280,7 @@ user community can engage in the development of your package.
 
 1.  Merge upstream with origin's devel branch,
 
+        git checkout -b devel
         git merge upstream/devel
 
     __NOTE:__ If you have the error `fatal: refusing to merge


### PR DESCRIPTION
In the subsection "[Create a new GitHub repository for an existing Bioconductor package](https://contributions.bioconductor.org/git-version-control.html#maintain-github-bioc)" within "Subversion to Git Transition" of the git version control page, there is a problem in steps 8 /9 of the guide. 

The user clones an empty repo from GitHub. He will start in the branch `main`. In step 8, the aim is to merge upstreams `devel` branch with origins `devel` branch, and push those changes in step 9. As the user is in the `main` branch, those changes will be merged to `main`. And in step 9 there appears an error, as the `devel` branch does not exist. So one has to create and checkout a new `devel` branch in origin first.