### PR TITLE
Reducing package file size by reducing screenshot sizes

### DIFF
--- a/general-package-development.Rmd
+++ b/general-package-development.Rmd
@@ -43,6 +43,7 @@ Do not use filenames that differ only in case, as not all file systems are case-
 ### Package size {#package-size}
 
 The source package resulting from running `R CMD build` should occupy less than 5 MB on disk.
+If your package includes (e.g. in the vignettes) some screenshots, this limit can be reached quite quickly. Their size can be reduced (often as much as 70%) in a lossy but quality-preserving manner by using tools such as [pngquant](https://pngquant.org/) (available as a command line utility and as a GUI on most systems).
 
 ### Check duration {#check-duration}
 

--- a/packages.bib
+++ b/packages.bib
@@ -3,30 +3,34 @@
   author = {{R Core Team}},
   organization = {R Foundation for Statistical Computing},
   address = {Vienna, Austria},
-  year = {2022},
+  year = {2024},
   url = {https://www.R-project.org/},
 }
 
 @Manual{R-bookdown,
   title = {bookdown: Authoring Books and Technical Documents with R Markdown},
   author = {Yihui Xie},
-  year = {2022},
-  note = {https://github.com/rstudio/bookdown},
+  year = {2024},
+  note = {R package version 0.38, 
+https://pkgs.rstudio.com/bookdown/},
+  url = {https://github.com/rstudio/bookdown},
 }
 
 @Manual{R-knitr,
   title = {knitr: A General-Purpose Package for Dynamic Report Generation in R},
   author = {Yihui Xie},
-  year = {2022},
-  note = {R package version 1.41},
+  year = {2023},
+  note = {R package version 1.45},
   url = {https://yihui.org/knitr/},
 }
 
 @Manual{R-rmarkdown,
   title = {rmarkdown: Dynamic Documents for R},
-  author = {JJ Allaire and Yihui Xie and Jonathan McPherson and Javier Luraschi and Kevin Ushey and Aron Atkins and Hadley Wickham and Joe Cheng and Winston Chang and Richard Iannone},
-  year = {2022},
-  note = {https://github.com/rstudio/rmarkdown},
+  author = {JJ Allaire and Yihui Xie and Christophe Dervieux and Jonathan McPherson and Javier Luraschi and Kevin Ushey and Aron Atkins and Hadley Wickham and Joe Cheng and Winston Chang and Richard Iannone},
+  year = {2024},
+  note = {R package version 2.26, 
+https://pkgs.rstudio.com/rmarkdown/},
+  url = {https://github.com/rstudio/rmarkdown},
 }
 
 @Book{bookdown2016,
@@ -35,7 +39,7 @@
   publisher = {Chapman and Hall/CRC},
   address = {Boca Raton, Florida},
   year = {2016},
-  note = {ISBN 978-1138700109},
+  isbn = {978-1138700109},
   url = {https://bookdown.org/yihui/bookdown},
 }
 
@@ -58,7 +62,6 @@
   publisher = {Chapman and Hall/CRC},
   year = {2014},
   note = {ISBN 978-1466561595},
-  url = {http://www.crcpress.com/product/isbn/9781466561595},
 }
 
 @Book{rmarkdown2018,
@@ -67,7 +70,7 @@
   publisher = {Chapman and Hall/CRC},
   address = {Boca Raton, Florida},
   year = {2018},
-  note = {ISBN 9781138359338},
+  isbn = {9781138359338},
   url = {https://bookdown.org/yihui/rmarkdown},
 }
 
@@ -77,7 +80,7 @@
   publisher = {Chapman and Hall/CRC},
   address = {Boca Raton, Florida},
   year = {2020},
-  note = {ISBN 9780367563837},
+  isbn = {9780367563837},
   url = {https://bookdown.org/yihui/rmarkdown-cookbook},
 }
 

--- a/shiny-apps.Rmd
+++ b/shiny-apps.Rmd
@@ -146,6 +146,10 @@ To set the name of an Rd document, use the `@name` tag in the Roxygen block:
 }
 ```
 
+Additionally, the vignette of a shiny app package might include some screenshots, either generated manually or programmatically.
+If generated manually, developers can use tools such as [pngquant](https://pngquant.org/) (available as a command line utility and as a GUI on most systems) to reduce their size (about 70%) without too much loss of quality.
+Programmatically generated screenshots can be realized by means of the [Webshot2](https://cran.r-project.org/package=webshot2) package, using the `webshot2::appshot()` function.
+
 ## Review
 
 When reviewing a shiny app package, the reviewer should check that the package


### PR DESCRIPTION
This contribution stems a bit from my painful/successful experience of having to comply with the 5Mb size limitation.

In brief: `pngquant` for the win.

I added this info at two relevant spots in the contributions guide, upon invitation of @lshep 😉 