### PR TITLE
Link to devel branch and spelling fixes

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -4,7 +4,9 @@ bookdown::bs4_book:
     yellow: "#804600"
     h4-font-size: "1.1rem"
     headings-color: "#87b13f"
-  repo: https://github.com/Bioconductor/pkgrevdocs
+  repo: 
+    base: https://github.com/Bioconductor/pkgrevdocs
+    branch: devel
 # Refer to https://rstudio.github.io/bslib/articles/bs4-variables.html for theme variable names
 
 bookdown::pdf_book:

--- a/description-file.Rmd
+++ b/description-file.Rmd
@@ -92,7 +92,7 @@ data. There are of course exceptions; please provide reasoning if included.
 All packages must be available via [_Bioconductor_'s biocViews][biocViews] or
 [CRAN][CRAN pkgs]; the use of the `Remotes:` field is not supported, hence dependencies only
 available on other repositories (e.g. <i class="fab fa-github"></i> GitHub) are
-not allowed nor is specifiy an explicit version of a package.
+not allowed nor is specify an explicit version of a package.
 
 Reuse, rather than re-implement or duplicate, well-tested functionality from
 other packages.  Make use of appropriate existing packages (e.g.,

--- a/documentation.Rmd
+++ b/documentation.Rmd
@@ -116,7 +116,7 @@ If appropriate, we strongly encourage a table of contents
 
 ### Evaluated code chunks
 
-Non-trival executable code is a must!!!
+Non-trivial executable code is a must!!!
 
 Static vignettes are not acceptable.
 

--- a/package-data.Rmd
+++ b/package-data.Rmd
@@ -35,7 +35,7 @@ mailing list.
 
 See the [Package Submission guidelines](#bioconductor-package-submissions) for
 further submission procedures and if submitting related or circular dependent
-packages please read [releated package submission procedure][cirdep]
+packages please read [related package submission procedure][cirdep]
 
 ## Adding Data to Existing Package {#adding-data-to-existing-package}
 

--- a/package-submission.Rmd
+++ b/package-submission.Rmd
@@ -225,7 +225,7 @@ AnnotationDbi.
 
 Annotation packages should *NOT* be posted to the tracker repository.
 Instead send an email to <packages@bioconductor.org> with a
-description of the proposed annotation package and futher instructions
+description of the proposed annotation package and further instructions
 of where to send the package will be provided. Whenever possible Annotation
 Packages should use the `r BiocStyle::Biocpkg("AnnotationHub")` for managing
 files.
@@ -296,13 +296,13 @@ use of existing data in a Bioconductor package. See development section on
 * If in the pre-review process there are identified larger issues with the
   package, a label `3e. pending pre-review changes` or a more specific flag of
   package issue will be assigned. Please address any pre-review identified
-  issues and comment back for the package admininstrators to re-evaluate.
+  issues and comment back for the package administrators to re-evaluate.
 
 * Once your package builds and checks without errors or (avoidable)
   warnings, the package is assigned a reviewer. The package will be
   labelled `2. Review in progress`.
 
-* The reviewr will provide a technical review of your package.  Other
+* The reviewer will provide a technical review of your package.  Other
   _Bioconductor_ developers and users with domain expertise are encouraged to
   provide additional community commentary.  Reviewers will add comments to the
   issue you created.
@@ -314,7 +314,7 @@ use of existing data in a Bioconductor package. See development section on
 * Respond to the issues raised by the reviewers. You _must_ respond to
   the primary reviewer, and are strongly encouraged to consider
   community commentary. Typically your response will involve code
-  modifications; commit these to the default branch of git.bioconductororg. When
+  modifications; commit these to the default branch of git.bioconductor.org. When
   you have addressed all concerns, add a comment to the issue created in step 2
   to explain your response.
 

--- a/r-code.Rmd
+++ b/r-code.Rmd
@@ -284,7 +284,7 @@ checks.
 * Do not use `browser()` in any internal <i class="fab fa-r-project"></i> code.
 * Avoid the use of `<<-`.
 * Avoid use of direct slot access with `@` or `slot()`. Accessor methods should be created and utilized
-* Use the packages `r BiocStyle::Biocpkg("ExperimentHub")` and `r BiocStyle::Biocpkg("AnnotationHub")` instead of downloading external data from unsanctioned providers such as <i class="fab fa-github"></i> GitHub, <i * class="fa fa-dropbox" aria-hidden="true"></i> Dropbox, etc. In general, data utlilzed in packages should be downloaded from trusted public databases. See also section on web querying and file caching.
+* Use the packages `r BiocStyle::Biocpkg("ExperimentHub")` and `r BiocStyle::Biocpkg("AnnotationHub")` instead of downloading external data from unsanctioned providers such as <i class="fab fa-github"></i> GitHub, <i * class="fa fa-dropbox" aria-hidden="true"></i> Dropbox, etc. In general, data utlilized in packages should be downloaded from trusted public databases. See also section on web querying and file caching.
 * Use `<-` instead of `=` for assigning variables except in function arguments.
 
 ### Cyclomatic Complexity

--- a/review-expectations.Rmd
+++ b/review-expectations.Rmd
@@ -53,7 +53,7 @@ not accept the issue until both packages are in an accepted state.
 ## Expectations and deadlines {.unnumbered #review-expectations-and-deadlines}
 
 Package[s] will be expected to be reviewed within 3 weeks of assignment and
-producea clean build report from the build machine.  We plan to make a hard
+produce a clean build report from the build machine.  We plan to make a hard
 limit for 3 weeks. If the delay is on the submitter, the issue will be closed
 for inactivity; it will be reopened when a submitter can commit to timely
 updates and engagement of the review process.  If the delay is in the reviewer,
@@ -97,7 +97,7 @@ package they can request someone offer additional comments (including those not
 officially part of the package review list) without explicitly asking for
 reassignment.
 
-Frequent requests for reassignement should consider a longer leave of absence
+Frequent requests for reassignment should consider a longer leave of absence
 agreement with the package review administrator. If frequent requests are being
 made for reassignement the reviewer will be notified and at risk for being
 removed from the active review process. If a reviewer is removed, they must

--- a/troubleshoot-build-report.Rmd
+++ b/troubleshoot-build-report.Rmd
@@ -27,7 +27,7 @@ with a valid version bump.
 
 ## How do I reproduce the build system ERROR?
 
-In order to reproduce the ERROR's accuately locally, remember to be using the
+In order to reproduce the ERROR's accurately locally, remember to be using the
 correct version of R and Bioconductor.  The version of R used for the build
 report can be found at the top of the [release][release-software-build-report] and
 [devel][devel-software-build-report] build reports. Once you are using the
@@ -103,8 +103,8 @@ R switched from 3.x to 4.0 which generally means some significant changes.
 - [Scalar / Vector Logic](#scalarvec)
 - [Class ==  vs  is/inherits](#classEq)
   - [Matrix is now Array](#matarr)
-- [data.frame stringAsFactors](#stringsAsFactors)
-- [stats::smoorthEnds](#statsSmoothEnds)
+- [data.frame stringsAsFactors](#stringsAsFactors)
+- [stats::smoothEnds](#statsSmoothEnds)
 - [grid package changes](#grid)
 - [plot generic moved](#plot)
 - [Partial Argument Matching](#partMatch)
@@ -381,7 +381,7 @@ these packages; when they are available, they will be added.
 CRAN packages are occasionally removed. Unfortunately, Bioconductor will only
 allow package dependencies to be actively maintained packages on CRAN or Bioconductor.
 A package will have to alter their package to not utilize code and not rely on this
-dependency. You may of course try to pentition CRAN for reinstatement or reach
+dependency. You may of course try to petition CRAN for reinstatement or reach
 out to the package maintainer to fix and submit to CRAN. Good Luck!
 
 #### Package has been removed from Bioconductor


### PR DESCRIPTION
I noticed a typo on a page and clicked the 'Edit this page' link but it points to the (legacy) master branch - I added a fix for that, fixed the spelling error I noticed, and ran a spellcheck to catch a handful more.