### PR TITLE
add fontawesome css for icons

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -1,4 +1,6 @@
 bookdown::bs4_book:
+  includes:
+    in_header: "includes/header.html"
   theme:
     primary: "#00758a"
     yellow: "#804600"

--- a/includes/header.html
+++ b/includes/header.html
@@ -1,0 +1,8 @@
+<head>
+  <link rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+  integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+  />
+</head>


### PR DESCRIPTION
Hi Lori, @lshep 

The fontawesome icons are not showing on my browser, e.g. the R logo in the title `3.1 Version of Bioconductor and` https://contributions.bioconductor.org/general.html. 
I am not sure if that is the case for you as well. 
Adding an `includes/header.html` to the repo and testing locally fixes it for me. 

One alternative is to use the `fontawesome` R package e.g., `fontawesome::fa("github")` but it would require a lot of manual intervention. 

Let me know if this works for you. 

-Marcel