### PR TITLE
Fix link reference in advanced-build-options.Rmd

### DIFF
--- a/advanced-build-options.Rmd
+++ b/advanced-build-options.Rmd
@@ -12,7 +12,7 @@ platform--`win`, `win64`, or `mac`--or the name of a build node. For example
     UnsupportedPlatforms: win64, kjohnson3
 
 **Note**: Newer packages should use `Config/Bioconductor/UnsupportedPlatforms`
-as described in [the DESCRIPTION file][description-file] for the transition to
+as described in [the DESCRIPTION file][description-unsupportedplatforms] for the transition to
 R Universe.
 
 ## Optional builds: long tests and GPU builds


### PR DESCRIPTION
Corrected reference to the DESCRIPTION file for UnsupportedPlatforms.