### PR TITLE
Resolve contradictory guidance on '.' in function names

### DIFF
--- a/r-code.Rmd
+++ b/r-code.Rmd
@@ -174,8 +174,9 @@ installation.
 Function names should follow the following conventions:
 
 * Use camelCase: initial lower case, then alternate case between words.
-* Do not use '.' (in the S3 class system, `some(x)` where `x` is class `A` will dispatch to `some.A`).
-* Prefix non-exported functions with a '.'.
+* Do not use '.' in exported function names (in the S3 class system, `some(x)` where `x` is
+  class `A` will dispatch to `some.A`), except to prefix non-exported/internal helper
+  functions with a leading dot: `.internalFunc`.
 
 #### Functional Programming and Length {#functional-programming-and-length}
 


### PR DESCRIPTION
The naming bullets said both:

  * Do not use '.' (in the S3 class system, some(x) where x is class A will dispatch to some.A).
  * Prefix non-exported functions with a '.'.

Read together these contradict each other, and a reader following the first bullet literally cannot follow the second. The intent is that the restriction applies to exported names, where a dot risks colliding with S3 dispatch, while a leading dot on an internal helper is the conventional way to mark it non-exported.

Merged into a single bullet stating both the rule and its exception.