### PR TITLE
Align reviewer eligibility between the volunteer and expectations chapters

### DIFF
--- a/volunteer-to-review.Rmd
+++ b/volunteer-to-review.Rmd
@@ -1,7 +1,7 @@
 # Volunteer to Review  {#review-volunteer-chapter}
 
-Anyone from the Bioconductor community can volunteer to become a Bioconductor
-community reviewer to review incoming packages submitted through the [New
-Submission Tracker][Packages Under Review]. Please review the [Reviewer
+Anyone from the Bioconductor community that has a package in Bioconductor can
+volunteer to become a Bioconductor community reviewer to review incoming
+packages submitted through the [New Submission Tracker][Packages Under Review]. Please review the [Reviewer
 Expectations](#review-expectation) and the _Bioconductor_ [Code of Conduct][] before filling out the
 [volunteer form](https://forms.gle/myLWsb7JVVrZa3xM9).


### PR DESCRIPTION
The two chapters state different eligibility criteria:

  volunteer-to-review.Rmd: 'Anyone from the Bioconductor community can
  volunteer to become a Bioconductor community reviewer'

  review-expectations.Rmd: 'Anyone from the Bioconductor community that
  has a package in Bioconductor can volunteer', with Qualifications
  giving 'Actively maintaining a Bioconductor package'

A reader arriving at the volunteer chapter first is told there is no prerequisite, then finds one in the chapter it links to. Added the qualifier to the volunteer chapter so both state the same requirement.

If the intent is instead that anyone may volunteer and maintaining a package is only required for assignment, the fix belongs in review-expectations.Rmd instead; happy to switch it around.